### PR TITLE
configuration.nix: add page

### DIFF
--- a/pages.ko/common/git-commit-graph.md
+++ b/pages.ko/common/git-commit-graph.md
@@ -1,0 +1,16 @@
+# git commit-graph
+
+> Git commit-graph 파일을 작성하고 검증합니다.
+> 더 자세한 정보: <https://git-scm.com/docs/git-commit-graph>.
+
+- 저장소의 로컬 `.git` 디렉토리에 있는 모든 커밋들에 대한 commit-graph 파일 작성:
+
+`git commit-graph write`
+
+- 모든 브랜치와 태그에서 접근 가능한 커밋들을 포함하는 commit-graph 파일 작성:
+
+`git show-ref --hash | git commit-graph write --stdin-commits`
+
+- 현재 commit-graph 파일의 모든 커밋과 현재 `HEAD`에서 접근 가능한 커밋들을 포함하는 업데이트된 commit-graph 파일 작성:
+
+`git rev-parse {{HEAD}} | git commit-graph write --stdin-commits --append`

--- a/pages.ko/common/git-commit-tree.md
+++ b/pages.ko/common/git-commit-tree.md
@@ -1,0 +1,21 @@
+# git commit-tree
+
+> Git의 내부 동작을 직접 다루는 명령어로, 커밋 객체를 직접 생성합니다.
+> 참조: `git commit`.
+> 더 자세한 정보: <https://git-scm.com/docs/git-commit-tree>.
+
+- 지정된 메시지로 커밋 객체 생성:
+
+`git commit-tree {{tree}} -m "{{message}}"`
+
+- 지정된 파일의 내용을 커밋 메시지로 사용하여 커밋 객체 생성 (`stdin`의 경우 `-` 사용):
+
+`git commit-tree {{tree}} -F {{path/to/file}}`
+
+- GPG 키로 인증된 커밋 객체 생성:
+
+`git commit-tree {{tree}} -m "{{message}}" --gpg-sign`
+
+- 지정된 부모 커밋 객체를 가진 커밋 객체 생성:
+
+`git commit-tree {{tree}} -m "{{message}}" -p {{parent_commit_sha}}`

--- a/pages.ko/common/git-config.md
+++ b/pages.ko/common/git-config.md
@@ -1,0 +1,37 @@
+# git config
+
+> Git 저장소의 사용자 지정 설정 옵션을 관리합니다.
+> 이러한 설정은 개별 (현재 저장소) 또는 전역 (현재 사용자)용일 수 있습니다.
+> 더 자세한 정보: <https://git-scm.com/docs/git-config>.
+
+- 전역으로 이름이나 이메일을 설정 (이 정보는 저장소에 커밋하는 데 필요하며 모든 커밋에 포함):
+
+`git config --global {{user.name|user.email}} "{{유저_이름|email@example.com}}"`
+
+- 개별 저장소 또는 전역 설정 항목을 나열:
+
+`git config --list --{{local|global}}`
+
+- 시스템 설정 항목만 나열하고(저장 위치: `/etc/gitconfig`), 파일 위치를 표시:
+
+`git config --list --system --show-origin`
+
+- 주어진 설정 항목의 값을 가져오기:
+
+`git config alias.unstage`
+
+- 주어진 설정 항목의 전역 값을 설정:
+
+`git config --global alias.unstage "reset HEAD --"`
+
+- 전역 설정 항목을 기본값으로 되돌리기:
+
+`git config --global --unset alias.unstage`
+
+- 개별 저장소의 Git 설정(`.git/config`)을 기본 편집기에서 편집:
+
+`git config --edit`
+
+- 전역 Git 설정(기본적으로 `~/.gitconfig` 또는 `$XDG_CONFIG_HOME/git/config` 파일이 존재하는 경우)을 기본 편집기에서 편집:
+
+`git config --global --edit`

--- a/pages.ko/common/git-ls-files.md
+++ b/pages.ko/common/git-ls-files.md
@@ -1,7 +1,7 @@
 # git ls-files
 
 > 색인과 작업 트리의 파일 정보를 보여줍니다.
-> 더 자세한 정보: <https://git-scm.com/docs/git-ls-files>.
+> 더 많은 정보: <https://git-scm.com/docs/git-ls-files>.
 
 - 삭제된 파일 보기:
 

--- a/pages.ko/common/git-ls-remote.md
+++ b/pages.ko/common/git-ls-remote.md
@@ -2,7 +2,7 @@
 
 > 원격 저장소의 브랜치, 태그 등의 정보를 나열하는 Git 명령어입니다.
 > 이름이나 URL이 주어지지 않으면 설정된 업스트림 브랜치를 사용하며, 업스트림이 설정되지 않은 경우 원격 origin을 사용합니다.
-> 더 자세한 정보: <https://git-scm.com/docs/git-ls-remote>.
+> 더 많은 정보: <https://git-scm.com/docs/git-ls-remote>.
 
 - 기본 원격 저장소의 모든 브랜치와 태그 정보 보기:
 

--- a/pages.ko/common/git-ls-tree.md
+++ b/pages.ko/common/git-ls-tree.md
@@ -1,7 +1,7 @@
 # git ls-tree
 
 > 트리 객체의 파일과 디렉토리 목록을 보여줍니다.
-> 더 자세한 정보: <https://git-scm.com/docs/git-ls-tree>.
+> 더 많은 정보: <https://git-scm.com/docs/git-ls-tree>.
 
 - 특정 브랜치의 파일과 디렉토리 목록 보기:
 

--- a/pages.ko/common/git-reflog.md
+++ b/pages.ko/common/git-reflog.md
@@ -1,0 +1,16 @@
+# git reflog
+
+> 로컬 Git 저장소의 브랜치, 태그, HEAD 등의 변경사항을 로그로 보여줍니다.
+> 더 자세한 정보: <https://git-scm.com/docs/git-reflog>.
+
+- HEAD의 변경된 기록을 표시:
+
+`git reflog`
+
+- 지정된 브랜치의 변경된 기록을 표시:
+
+`git reflog {{브랜치_이름}}`
+
+- 변경된 기록의 최근 5개 항목만 표시:
+
+`git reflog -n {{5}}`

--- a/pages.ko/common/git-remote.md
+++ b/pages.ko/common/git-remote.md
@@ -1,7 +1,7 @@
 # git remote
 
 > 원격 저장소(remote repositories)를 관리하는 명령어입니다.
-> 더 자세한 정보: <https://git-scm.com/docs/git-remote>.
+> 더 많은 정보: <https://git-scm.com/docs/git-remote>.
 
 - 이름과 URL을 포함한 기존 원격 저장소 목록 보기:
 

--- a/pages.ko/common/git-stash.md
+++ b/pages.ko/common/git-stash.md
@@ -1,0 +1,36 @@
+# git stash
+
+> 로컬 Git 변경사항을 임시 영역에 저장합니다.
+> 더 자세한 정보: <https://git-scm.com/docs/git-stash>.
+
+- 새롭게 생성한 (Git에서 관리하지 않는) 파일을 제외하고 현재 변경사항을 메시지와 함께 임시 저장:
+
+`git stash push --message {{optional_stash_message}}`
+
+- 새롭게 생성한 (Git에서 관리하지 않는) 파일을 포함하여 현재 변경사항을 임시 저장:
+
+`git stash --include-untracked`
+
+- 변경된 파일들의 특정 부분만 선택하여 임시 저장 (대화형 프롬프트):
+
+`git stash --patch`
+
+- 모든 임시 저장 목록 표시 (임시 저장 이름, 관련 브랜치 및 메시지 표시):
+
+`git stash list`
+
+- 임시 저장(기본값은 `stash@{0}`)과 해당 임시 저장이 생성된 시점의 커밋 사이의 변경 사항을 터미널에 상세히 표시:
+
+`git stash show --patch {{stash@{0}}}`
+
+- 임시 저장 적용 (기본값은 가장 최근 임시 저장인 stash@{0}):
+
+`git stash apply {{optional_stash_name_or_commit}}`
+
+- 임시 저장을 적용하고 (기본값은 stash@{0}), 적용 시 충돌이 없으면 임시 저장 목록에서 제거:
+
+`git stash pop {{optional_stash_name}}`
+
+- 모든 임시 저장 삭제:
+
+`git stash clear`

--- a/pages.pt_BR/linux/ascii.md
+++ b/pages.pt_BR/linux/ascii.md
@@ -1,7 +1,7 @@
 # ascii
 
 > Mostra pseudónimos de caractéres ASCII.
-> Mais informações em: <http://www.catb.org/~esr/ascii/>.
+> Mais informações: <http://www.catb.org/~esr/ascii/>.
 
 - Mostra pseudónimos ASCII de um carácter:
 


### PR DESCRIPTION
- [x] The page (if new), does not already exist in the repo.
- [x] The page is in the correct platform directory (common/, linux/, etc.)
- [x] The page has 8 or fewer examples.
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).

In [NixOS](https://nixos.org/manual/nixos/stable/#sec-configuration-syntax), configuration.nix is a main file that specifies the system configuration.